### PR TITLE
Add cibuildwheels

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -6,9 +6,12 @@ jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    env:
+      MACOSX_DEPLOYMENT_TARGET: "10.9"
+      CFLAGS: "-std=c++11"
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019] # macos-11 known c++11 build issue
+        os: [macos-11]  # ubuntu-20.04, windows-2019,
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,0 +1,28 @@
+name: build wheels
+
+on: [push, pull_request]
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-2019] # macos-11 known c++11 build issue
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.16.0
+        # env:
+        #   CIBW_SOME_OPTION: value
+        #    ...
+        # with:
+        #   package-dir: .
+        #   output-dir: wheelhouse
+        #   config-file: "{package}/pyproject.toml"
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -7,24 +7,18 @@ jobs:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     env:
-      MACOSX_DEPLOYMENT_TARGET: "10.9"
       CFLAGS: "-std=c++11"
+      CIBW_TEST_REQUIRES: pytest
+      CIBW_TEST_COMMAND: cd {package} && ls
     strategy:
       matrix:
-        os: [macos-11]  # ubuntu-20.04, windows-2019,
+        os: [ubuntu-20.04, windows-2019, macos-11]
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.0
-        # env:
-        #   CIBW_SOME_OPTION: value
-        #    ...
-        # with:
-        #   package-dir: .
-        #   output-dir: wheelhouse
-        #   config-file: "{package}/pyproject.toml"
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 test*
+!isosplit6/tests
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-test*
-!isosplit6/tests
-
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/isosplit6/tests/test_simple_run.py
+++ b/isosplit6/tests/test_simple_run.py
@@ -1,0 +1,14 @@
+from isosplit6 import isosplit6
+import numpy as np
+from numpy.typing import NDArray
+
+def test_isosplit6_runs():
+    """
+    A simple test to check that isosplit6 runs.
+    Useful for testing wheels are successfully built.
+    """
+    data = np.random.random((100, 100))
+
+    result = isosplit6(data)
+
+    assert isinstance(result, np.ndarray)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,3 +17,9 @@ extend-ignore = [
   "E501",   # Line too long
 ]
 target-version = "py37"
+
+[tool.cibuildwheel]
+build = "cp38-* cp39-* cp310-*"
+
+[tool.cibuildwheel.macos]
+archs = ["x86_64", "arm64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,8 @@
 requires = [
     "setuptools>=42",
     "pybind11>=2.10.0",
+    "numpy",
+    "pytest",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -19,7 +21,7 @@ extend-ignore = [
 target-version = "py37"
 
 [tool.cibuildwheel]
-build = "cp38-* cp39-* cp310-*"
+build = "cp37-* cp38-* cp39-* cp310-* cp311-*"
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,15 @@
 requires = [
     "setuptools>=42",
     "pybind11>=2.10.0",
-    "numpy",
-    "pytest",
 ]
 build-backend = "setuptools.build_meta"
+
+[pyproject.optional-dependencies]
+dev = [
+    "numpy",  # required for tests
+    "pytest",
+    "ruff",
+]
 
 [tool.ruff]
 extend-select = [


### PR DESCRIPTION
Hi @magland, this PR adds CI for `cibuildwheels` which is a nice tool that automates building many wheels cross-platform using CI. These can then be downloaded either from the Actions page Summary (at the bottom) once the workflow has run, or this could be configured to run and automatically push to pypi on new version release.

Currently this runs `on: [push, pull_request]` but maybe it would be better to either run with a commit prompt, or on new version release and deploy to pypi.

A summary of the changes:
- Add `build_wheels.yaml` which will automate the wheel building on CI.
- Add a quick test just to check `isosplit6` runs, to check wheels have built properly. This required adding `tests/` directory at top level, removing `test*` from the `.gitignore` and adding a couple of optional `[dev]` dependencies in the pyproject.toml

An example of the output is [here](https://github.com/JoeZiminski/isosplit6/actions/runs/6277789710), the wheels can be downloaded manually from the Artifacts section under the Summary tab.