### PR TITLE
Add build to CI and upload build and wheels on new version.

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - '*'
-  pull_request:
 
 jobs:
   build_wheels:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,6 +1,9 @@
-name: build wheels
+name: build and deploy
 
-on: [push, pull_request]  # TODO: on release with tags
+on:
+  push:
+    tags:
+      - '*'
 
 jobs:
   build_wheels:
@@ -52,6 +55,6 @@ jobs:
         name: artifact
         path: dist
 
-#    - uses: pypa/gh-action-pypi-publish@release/v1
-#      with:
-#        password: ${{ secrets.PYPI_API_TOKEN }}
+    - uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - '*'
+  pull_request:
 
 jobs:
   build_wheels:
@@ -34,7 +35,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0  # Optional, use if you use setuptools_scm
-        submodules: true  # Optional, use if you have submodules
+        submodules: false  # Optional, use if you have submodules
 
     - name: Build SDist
       run: pipx run build --sdist

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,6 +1,6 @@
 name: build wheels
 
-on: [push, pull_request]
+on: [push, pull_request]  # TODO: on release with tags
 
 jobs:
   build_wheels:
@@ -23,3 +23,35 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
+
+  make_sdist:
+    name: Make SDist
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0  # Optional, use if you use setuptools_scm
+        submodules: true  # Optional, use if you have submodules
+
+    - name: Build SDist
+      run: pipx run build --sdist
+
+    - uses: actions/upload-artifact@v3
+      with:
+        path: dist/*.tar.gz
+
+  upload_all:
+    needs: [build_wheels, make_sdist]
+    environment: pypi
+    permissions:
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: artifact
+        path: dist
+
+#    - uses: pypa/gh-action-pypi-publish@release/v1
+#      with:
+#        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Hi @magland,

This PR extends #2 by building and uploading wheels to pypi as part of the CI. The sections for building and uploading are taken almost verbatim from the [cibuildwheel docs](https://cibuildwheel.readthedocs.io/en/stable/deliver-to-pypi/) and seem to work okay. This workflow should only run when a tag is pushed. It will build the wheels (as in #2), build the tarball and upload it all to pypi.

I have tested by running everything up to the actual upload, and checking the tarball that was created during the CI run works okay. However the thing I could not test is adding the API key and the actual upload to PyPI (I think the API key procedure will be the same as was used for Mountainsort5, happy to help with this, although it's been a while since I have done it 😅 ). Once this is setup I think it can be tested by pushing a version `0.1.3rc0` release candidate and it it's working, push with tag `0.1.3`. Happy to test the release candidate on macOS to double check everything has worked with the wheels!

closes #3 
