### PR TITLE
Update `build-and-deploy.yml` to run on tag push.

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -4,7 +4,7 @@ on:
   push:
     tags:
       - '*'
-  workflow_dispatch:
+
 jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}


### PR DESCRIPTION
This PR removes `workflow_dispatch:` from the `build-and-deploy` workflow, which I think was stopping the action run when tag was pushed.