### PR TITLE
Update macos runners for ci build wheels

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -15,7 +15,7 @@ jobs:
       CIBW_TEST_COMMAND: cd {package} && ls
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-11]
+        os: [ubuntu-20.04, windows-2019, macos-13, macos-14]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Hi @magland, I'm having some trouble installing `mountainsort5` on M2 silicon mac. I think the runners for the `cibuildwheels` have gone out of date, and github is not longer supporting the `macos-11` runners. 

This PR adds `macos-13` and `macos-14` to the runners, which should ensure wheels are built for macos silicon and the most recent macos intel (if I understand [this](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners) correctly).